### PR TITLE
Add frame skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ ROMs may be loaded from compressed files with the following caveats:
 
 
 
+#### Frame skipping
+
+Some ROMs may need frame skipping enabled for acceptable performance. A typical
+problem that frame skipping can work around is if the audio is making
+crackling, stuttering, or popping sounds.
+
+Enable frame skipping by going to the core options and setting *Frameskip type*
+to *auto* or *manual* as desired. Then set *Frameskip value* to *1* and
+increase it as necessary.
+
+Known games that benefit from frame skipping enabled:
+
+- Metroid: Zero Mission
+- Mother 3
+
+
+
 ## Compiling
 
 #### Compile retroarch core using libretro-super

--- a/README.md
+++ b/README.md
@@ -43,21 +43,27 @@ ROMs may be loaded from compressed files with the following caveats:
 - Each .zip file must contain only one ROM
 
 
-
 #### Frame skipping
 
 Some ROMs may need frame skipping enabled for acceptable performance. A typical
 problem that frame skipping can work around is if the audio is making
 crackling, stuttering, or popping sounds.
 
-Enable frame skipping by going to the core options and setting *Frameskip type*
-to *auto* or *manual* as desired. Then set *Frameskip value* to *1* and
-increase it as necessary.
+Enable frame skipping by going to the core options and set *Frameskip type* as
+desired:
 
-Known games that benefit from frame skipping enabled:
+- *manual* will use a consistent framerate that will be slower but smoother
+- *auto* will use a variable framerate that will only slow down when necessary
+  at the risk of choppier video when this happens
 
-- Metroid: Zero Mission
-- Mother 3
+*Frameskip value* determines the number of frames that will be skipped per
+frame played. Generally, the lower the better. For example, setting this to *1*
+will skip every other frame, cutting the framerate from the default 60 FPS to
+30 FPS.
+
+See here to get an idea of games that may benefit from frame skipping:
+
+[TempGBA Compatibility List](https://wiki.gbatemp.net/wiki/TempGBA_Compatibility)
 
 
 

--- a/libretro.c
+++ b/libretro.c
@@ -20,7 +20,8 @@ static SceUID cpu_thread;
 
 /* Disable frame skipping by default since most games don't seem to need it */
 static u32 option_frameskip_type = FRAMESKIP_NONE;
-static u32 option_frameskip_value = 9;
+/* Use a low default for less choppy video when frame skipping is enabled */
+static u32 option_frameskip_value = 1;
 static u32 num_skipped_frames = 0;
 /* Count of the actual number of frames drawn */
 static u32 real_frame_count = 0;

--- a/libretro.c
+++ b/libretro.c
@@ -409,25 +409,27 @@ void retro_run(void)
 
    input_poll_cb();
 
-   // uint64_t start_tick, end_tick;
-   // sceRtcGetCurrentTick(&start_tick);
-
+#ifdef HW_RENDER_TEST
+   uint64_t start_tick, end_tick;
+   sceRtcGetCurrentTick(&start_tick);
+#endif
 
    switch_to_cpu_thread();
 
    update_input();
 
+#ifdef HW_RENDER_TEST
+   sceRtcGetCurrentTick(&end_tick);
+// printf("frame time : %u\n", (uint32_t)(end_tick - start_tick));
+   static int frames = 0;
+   static float total = 0.0;
 
-   // sceRtcGetCurrentTick(&end_tick);
-//   printf("frame time : %u\n", (uint32_t)(end_tick - start_tick));
-   // static int frames = 0;
-   // static float total = 0.0;
+   if ( frames >= 200)
+      total += (end_tick - start_tick);
 
-   // if ( frames >= 200)
-   //    total += (end_tick - start_tick);
-
-   // if (frames++ == 400)
-   //    printf("total : %f\n", total / 200.0);
+   if (frames++ == 400)
+      printf("total : %f\n", total / 200.0);
+#endif
 
    render_audio();
 

--- a/libretro.c
+++ b/libretro.c
@@ -476,7 +476,9 @@ void retro_run(void)
       video_cb(RETRO_HW_FRAME_BUFFER_VALID, GBA_SCREEN_WIDTH, GBA_SCREEN_HEIGHT, GBA_LINE_SIZE * 2);
    else
 #endif
-      video_cb(RETRO_HW_FRAME_BUFFER_VALID, GBA_SCREEN_WIDTH, GBA_SCREEN_HEIGHT, 512);
+      /* Skip the video callback when skipping frames so the frontend can properly report FPS */
+      if (!skip_next_frame)
+         video_cb(RETRO_HW_FRAME_BUFFER_VALID, GBA_SCREEN_WIDTH, GBA_SCREEN_HEIGHT, 512);
 }
 
 unsigned retro_api_version(void)

--- a/main.c
+++ b/main.c
@@ -74,7 +74,6 @@ u8 cpu_init_state = 0;
 
 u32 skip_next_frame = 0;
 u32 frames = 0;
-u32 vblank_count = 0;
 
 static u8 caches_inited = 0;
 
@@ -495,6 +494,9 @@ static void init_main(void)
 void quit_gba(void)
 {
   memory_term();
+
+  sceKernelDisableSubIntr(PSP_VBLANK_INT, 0);
+  sceKernelReleaseSubIntrHandler(PSP_VBLANK_INT, 0);
 }
 
 void reset_gba(void)

--- a/main.c
+++ b/main.c
@@ -72,6 +72,7 @@ s32 video_count = 272;
 u32 irq_ticks = 0;
 u8 cpu_init_state = 0;
 
+u32 skip_next_frame = 0;
 u32 frames = 0;
 u32 vblank_count = 0;
 
@@ -288,7 +289,8 @@ u32 update_gba(void)
            else
 #endif
            {
-             update_scanline();
+              if (!skip_next_frame)
+                 update_scanline();
            }
 
           // If in visible area also fire HDMA
@@ -448,7 +450,6 @@ static void init_main(void)
   s32 i;
 
   init_cpu();
-
 
   for (i = 0; i < 4; i++)
   {

--- a/main.h
+++ b/main.h
@@ -60,9 +60,9 @@ extern u32 option_enable_analog;
 extern u32 option_analog_sensitivity;
 extern u32 option_language;
 
-extern u32 option_frameskip_type;
-extern u32 option_frameskip_value;
 extern u32 option_clock_speed;
+
+extern u32 skip_next_frame;
 
 extern char main_path[MAX_PATH];
 extern char dir_save[MAX_PATH];

--- a/main.h
+++ b/main.h
@@ -72,12 +72,6 @@ extern u32 enable_home_menu;
 
 extern u32 sleep_flag;
 
-extern u32 synchronize_flag;
-extern u32 psp_fps_debug;
-
-extern u32 real_frame_count;
-extern u32 virtual_frame_count;
-
 void direct_sound_timer_select(u32 value);
 
 void timer_control_low(u8 timer_number, u32 value);


### PR DESCRIPTION
Fixes #4 

As discussed, I left frame skipping off by default. I also set the default frameskip value to 1 for less choppy video if frame skipping is enabled. And I added some notes to the readme.

I more or less tried my best to copy the implementation from upstream. This is the best reference since the original TempGBA4PSP isn't on GitHub:

https://github.com/phoe-nix/TempGBA4PSP-mod/blob/0e4cc6b29062c6fb4f54dae1353aff0788f6fb00/source/src/main.c#L579-L617

Feel free to rewrite any of this as needed. This definitely isn't my area of expertise!